### PR TITLE
simplify httpInterceptor pattern

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,8 @@ func httpInterceptor(router http.Handler) http.Handler {
 
         router.ServeHTTP(w, req)
 
-        elapsedTime := time.Now().Sub(startTime)
+        finishTime := time.Now()
+        elapsedTime := finishTime.Sub(startTime)
 
         switch req.Method {
         case "GET":


### PR DESCRIPTION
Sorry the changes show every line changed, gofmt did that.

The actual fix is to simplify the httpInterceptor pattern.  Since a mux satisfies the handler interface we can avoid the global router var by passing the router to the httpInterceptor ([L#21](https://github.com/bryfry/git-go-websiteskeleton/blob/master/main.go#L21) and [L#35-53](https://github.com/bryfry/git-go-websiteskeleton/blob/master/main.go#L35-53)) and perform the ServeHTTP on it ([L#39](https://github.com/bryfry/git-go-websiteskeleton/blob/master/main.go#L39)).  

You need to do the right dance at the function definition to get all three needed vars inside the function (router, w, req) ([#L35-36](https://github.com/bryfry/git-go-websiteskeleton/blob/master/main.go#L35-36)) but that aside there isn't any thing special about it.
