### PR TITLE
Enabled TLS connection into skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 access_log.txt
 main
 !main.go
+key.pem
+cert.pem

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ A basic website skeleton in Go (or golang, if you prefer) that comes with the Go
 1. A go environment http://golang.org/doc/install#install
 2. Gorilla mux: go get github.com/gorilla/mux (http://www.gorillatoolkit.org/pkg/mux)
 3. glog: go get github.com/golang/glog
-4. Some basic knowledge of Go's httpd package. See the excellent gowiki tutorial at http://golang.org/doc/articles/wiki/
+4. httpscerts: github.com/kabukky/httpscerts
+5. secureheader: go get github.com/kr/secureheader
+6. Some basic knowledge of Go's httpd package. See the excellent gowiki tutorial at http://golang.org/doc/articles/wiki/
 
 ### Installation ###
 1. cd $GOPATH/src
 2. git clone https://github.com/jadekler/git-go-websiteskeleton.git
 3. cd git-go-websiteskeleton
 4. go run main.go
-5. Navigate to http://localhost:8080
+5. Navigate to https://localhost:8080
 
 Note: To make it your own project, simply remove the .git file from the project and upload it into your own repository.
 
@@ -28,5 +30,5 @@ requested, and the page load time.
 
 Note: on *nix systems, you can also set the TMPDIR environment variable to specify default output location.
 
-### What if I want to use Secure Headers? ###
-This doesn't come with the default skeleton, but feel free to check out and implement things like http://godoc.org/github.com/kr/secureheader (which are very easy to get up and running!).
+## TLS connection ###
+Currently this skeleton is created for TLS connection and using auto-created certificate. Just create/replace key.pem and cert.pem  with your own if you want to use real certificate. These files are not ander Git control.

--- a/main.go
+++ b/main.go
@@ -11,6 +11,9 @@ import (
 
     "github.com/golang/glog"
     "github.com/gorilla/mux"
+
+    "github.com/kabukky/httpscerts"
+    "github.com/kr/secureheader"
 )
 
 func main() {
@@ -29,7 +32,13 @@ func main() {
     fileServer := http.StripPrefix("/static/", http.FileServer(http.Dir("static")))
     http.Handle("/static/", fileServer)
 
-    http.ListenAndServe(":8080", nil)
+    err := httpscerts.Check("cert.pem", "key.pem")
+    // If they are not available, generate new ones.
+    if err != nil {
+        httpscerts.Generate("cert.pem", "key.pem", "127.0.0.1:8080")
+    }
+
+    http.ListenAndServeTLS(":8080", "cert.pem", "key.pem", secureheader.DefaultConfig)
 }
 
 func httpInterceptor(router http.Handler) http.Handler {


### PR DESCRIPTION
I think that enabled TLS connection is good point for this skeleton. It's just few lines of code, but it's so easy in future to change *.pem files to your own and use full secured connection. But there are some disadvantages in this change: new imports, auto-generated certificate by default. 
